### PR TITLE
Use environment variables for credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ docs/_build/
 
 # pycharm .idea
 .idea
+
+# .env
+.env

--- a/DemoAIs/.env.sample
+++ b/DemoAIs/.env.sample
@@ -1,0 +1,3 @@
+# Copy this file to ".env" and insert your credentials
+USERNAME="YOUR-USERNAME"
+PASSWORD="YOUR-PASSWdORD"

--- a/DemoAIs/BOAIapi.py
+++ b/DemoAIs/BOAIapi.py
@@ -3,6 +3,10 @@ from enum import Enum
 
 import requests
 
+import os
+from dotenv import load_dotenv
+load_dotenv()
+
 
 class GameState(Enum):
     WAITING = "WAITING"
@@ -26,7 +30,8 @@ class BOAIapi:
 
     """
 
-    def __init__(self, username, password, func, play_games_i_already_left=True, verbose=0,
+    def __init__(self, func, username=os.getenv("USERNAME"), password=os.getenv("PASSWORD"),
+                 play_games_i_already_left=True, verbose=0,
                  games_api_url="https://games.battleofai.net/api/",
                  account_management_api_url="https://iam.battleofai.net/api/"):
         self.username = username

--- a/DemoAIs/Config.py
+++ b/DemoAIs/Config.py
@@ -1,2 +1,0 @@
-username = "USERNAME"
-password = "PASSWORD"

--- a/DemoAIs/core.py
+++ b/DemoAIs/core.py
@@ -22,9 +22,9 @@ def turn(board, symbol):
 # If you should find any bug in this API-Wrapper (or the API),
 # please report it.
 # Before this "ai" will at least do something, you have to change
-# the login credentials in "Config.py"
+# the login credentials in ".env" (see ".env.sample")
 #
-api = BOAIapi(username, password, turn, verbose=1)
+api = BOAIapi(turn, verbose=1)
 
 while True:
     api.handle_available()

--- a/DemoAIs/requirements.txt
+++ b/DemoAIs/requirements.txt
@@ -1,0 +1,1 @@
+python-dotenv==0.9.1


### PR DESCRIPTION
## Description
Storing one's own credentials in a file tracked by git is not a good idea, because sooner or later this would lead to someone accidentally publishing their credentials. To prevent this, [`.env` files](https://pypi.org/project/python-dotenv/ "python-dotenv") are often used.

## Related Issue
Closes #11 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project. (Is there a style guide?)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

I adjusted the demo AI and created a sample (`.env.sample`) with a comment for the `.env` file, so it should be relatively self-explanatory. This change should probably be documented somewhere anyway. 